### PR TITLE
Make sure that the input to tolower are of type string

### DIFF
--- a/src/niweb/apps/noclook/views/detail.py
+++ b/src/niweb/apps/noclook/views/detail.py
@@ -705,7 +705,7 @@ def site_detail(request, handle_id):
     MATCH (site:Site {handle_id: $handle_id})-[:Has]->(rack:Rack)
     OPTIONAL MATCH (rack)<-[:Located_in]-(item:Node)
     WHERE NOT item.operational_state IN ['Decommissioned'] OR NOT exists(item.operational_state)
-    RETURN rack, item order by toLower(rack.name), toLower(item.name)
+    RETURN rack, item order by toLower(toString(rack.name)), toLower(toString(item.name))
     """
     rack_list = nc.query_to_list(nc.graphdb.manager, q, handle_id=nh.handle_id)
 
@@ -716,7 +716,7 @@ def site_detail(request, handle_id):
     # rooms
     q = """
         MATCH (site:Site {handle_id: $handle_id})-[:Has]->(room:Room)
-        RETURN room order by toLower(room.name)
+        RETURN room order by toLower(toString(room.name))
         """
     rooms_list = nc.query_to_list(nc.graphdb.manager, q, handle_id=nh.handle_id)
 
@@ -755,7 +755,7 @@ def room_detail(request, handle_id):
     MATCH (room:Room {handle_id: $handle_id})-[:Has]->(rack:Node)
     OPTIONAL MATCH (rack)<-[:Located_in]-(item:Node)
     WHERE NOT item.operational_state IN ['Decommissioned'] OR NOT exists(item.operational_state)
-    RETURN rack, item order by toLower(rack.name), toLower(item.name)
+    RETURN rack, item order by toLower(toString(rack.name)), toLower(toString(item.name))
     """
     rack_list = nc.query_to_list(nc.graphdb.manager, q, handle_id=nh.handle_id)
 

--- a/src/niweb/apps/noclook/views/list.py
+++ b/src/niweb/apps/noclook/views/list.py
@@ -156,7 +156,7 @@ def list_ports(request):
     q = """
         MATCH (port:Port)
         OPTIONAL MATCH (port)<-[:Has]-(parent:Node)
-        RETURN port, collect(parent) as parent order by toLower(port.name)
+        RETURN port, collect(parent) as parent order by toLower(toString(port.name))
         """
     port_list = nc.query_to_list(nc.graphdb.manager, q)
     port_list = _filter_expired(port_list, request, select=lambda n: n.get('port'))


### PR DESCRIPTION
The `toLower()` function in Neo4j is defined as:

```
toLower(string) -> string
```

However, some customers have `Room` nodes where the `name` property is stored as an integer or long (e.g., `5505`). This causes an exception when executing queries like the following:

```cypher
MATCH (site:Site {handle_id: 1747})-[:Has]->(room:Room)
RETURN room ORDER BY toLower(room.name)
```

The exception occurs because `toLower()` expects a string input, but it encounters a numeric value instead.

`neobolt.exceptions.CypherTypeError: Expected a string value for toLower, but got: Long(5101); consider converting it to a string with toString().`
### Quick-Fix

The `toString()` function has been added before every `toLower()` call, ensuring the input is always converted to a string:

```cypher
...ORDER BY toLower(toString(room.name))
```

### Improvement
A better long-term solution would be to enforce the `name` property (and other relevant properties) as a string during the data creation process. This would ensure consistency across all nodes and prevent similar issues in the future.