### PR TITLE
Optical node map updates

### DIFF
--- a/src/niweb/apps/noclook/templates/noclook/detail/optical_path_detail.html
+++ b/src/niweb/apps/noclook/templates/noclook/detail/optical_path_detail.html
@@ -67,7 +67,11 @@
 {% if user.is_staff %}
     <a href="edit" class="btn btn-info"><i class="icon-edit icon-white"></i> Edit</a>
 {% endif %}
-<a href="/gmaps/optical-nodes/?path={{ node.data.handle_id }}" class="btn btn-primary"><i class="icon-map-marker icon-white"></i> Show in Optical Node Map</a>
-<a href="/optical-path/{{ node.data.handle_id }}/kmz/" class="btn btn-success"><i class="icon-download-alt icon-white"></i> Download KMZ</a>
 {% include "noclook/detail/includes/depend_include.html" %}
+{% endblock %}
+
+{% block content_footer %}
+    {{ block.super }}
+    <a href="/gmaps/optical-nodes/?path={{ node.data.handle_id }}" class="btn btn-info"><i class="icon-map-marker icon-white"></i> Show in Optical Node Map</a>
+    <a href="/optical-path/{{ node.data.handle_id }}/kmz/" class="btn btn-info"><i class="icon-download-alt icon-white"></i> Download KMZ</a>
 {% endblock %}

--- a/src/niweb/apps/noclook/templates/noclook/detail/optical_path_detail.html
+++ b/src/niweb/apps/noclook/templates/noclook/detail/optical_path_detail.html
@@ -68,5 +68,6 @@
     <a href="edit" class="btn btn-info"><i class="icon-edit icon-white"></i> Edit</a>
 {% endif %}
 <a href="/gmaps/optical-nodes/?path={{ node.data.handle_id }}" class="btn btn-primary"><i class="icon-map-marker icon-white"></i> Show in Optical Node Map</a>
+<a href="/optical-path/{{ node.data.handle_id }}/kmz/" class="btn btn-success"><i class="icon-download-alt icon-white"></i> Download KMZ</a>
 {% include "noclook/detail/includes/depend_include.html" %}
 {% endblock %}

--- a/src/niweb/apps/noclook/templates/noclook/detail/optical_path_detail.html
+++ b/src/niweb/apps/noclook/templates/noclook/detail/optical_path_detail.html
@@ -67,5 +67,6 @@
 {% if user.is_staff %}
     <a href="edit" class="btn btn-info"><i class="icon-edit icon-white"></i> Edit</a>
 {% endif %}
+<a href="/gmaps/optical-nodes/?path={{ node.data.handle_id }}" class="btn btn-primary"><i class="icon-map-marker icon-white"></i> Show in Optical Node Map</a>
 {% include "noclook/detail/includes/depend_include.html" %}
 {% endblock %}

--- a/src/niweb/apps/noclook/templates/noclook/google_maps.html
+++ b/src/niweb/apps/noclook/templates/noclook/google_maps.html
@@ -69,6 +69,18 @@
             redrawAllPaths();
         });
         
+        // Set up event delegation for path checkbox changes
+        $('#path_list').on('change', '.path-checkbox', function() {
+            var pathKey = $(this).data('path-key');
+            if ($(this).is(':checked')) {
+                selectedPaths[pathKey] = true;
+                drawOpticalPath(availablePaths[pathKey], pathKey);
+            } else {
+                delete selectedPaths[pathKey];
+                redrawAllPaths(); // Redraw all paths with correct spacing
+            }
+        });
+        
         load_content(map);
     }
     
@@ -140,7 +152,13 @@
         var pathListHtml = '';
         
         paths.forEach(function(path) {
-            var pathKey = nodeHandleId + '_' + path.id;
+            // Use just the path ID as the key to avoid duplicates
+            var pathKey = path.id.toString();
+            
+            // Skip if this path is already displayed (checked or not)
+            if ($('.path-checkbox[data-path-key="' + pathKey + '"]').length > 0) {
+                return; // Path already in the list, skip it
+            }
             
             // Store path data if not already stored
             if (!availablePaths[pathKey]) {
@@ -151,11 +169,14 @@
             var checked = selectedPaths[pathKey] ? 'checked' : '';
             var colorIndicator = '<span class="path-color-indicator" style="background-color:' + availablePaths[pathKey].color + '"></span>';
             
+            // Construct the optical path URL
+            var pathUrl = '/optical-path/' + path.id + '/';
+            
             pathListHtml += '<div class="path-item">';
             pathListHtml += '<label>';
             pathListHtml += '<input type="checkbox" class="path-checkbox" data-path-key="' + pathKey + '" ' + checked + '>';
             pathListHtml += colorIndicator;
-            pathListHtml += '<strong>' + path.name + '</strong>';
+            pathListHtml += '<a href="' + pathUrl + '" target="_blank" style="text-decoration: none; color: #1a0dab; font-weight: 500;">' + path.name + '</a>';
             if (path.description) {
                 pathListHtml += '<br><small>' + path.description + '</small>';
             }
@@ -164,19 +185,9 @@
             pathListHtml += '</div>';
         });
         
-        $('#path_list').append(pathListHtml);
-        
-        // Add checkbox handlers
-        $('.path-checkbox').on('change', function() {
-            var pathKey = $(this).data('path-key');
-            if ($(this).is(':checked')) {
-                selectedPaths[pathKey] = true;
-                drawOpticalPath(availablePaths[pathKey], pathKey);
-            } else {
-                delete selectedPaths[pathKey];
-                removeOpticalPath(pathKey);
-            }
-        });
+        if (pathListHtml) {
+            $('#path_list').append(pathListHtml);
+        }
     }
     
    function drawOpticalPath(pathData, pathKey) {
@@ -432,21 +443,6 @@
             }
 
             function addLine(start_lat, start_lng, end_lat, end_lng, label, url){
-                var infowindow = new google.maps.InfoWindow({
-                    content: "<div style='padding: 2px 4px; font-size: 12px;'><span style='color: #666; font-size: 11px;'>Optical Link:</span><br/><a href='" + url + "' style='text-decoration: none; color: #1a0dab; font-weight: 500;'>" + label + "</a></div>",
-                    disableAutoPan: true
-                });
-                
-                // Hide close button when opened
-                google.maps.event.addListener(infowindow, 'domready', function() {
-                    setTimeout(function() {
-                        var closeButtons = document.querySelectorAll('.gm-ui-hover-effect');
-                        closeButtons.forEach(function(btn) {
-                            btn.style.display = 'none';
-                        });
-                    }, 10);
-                });
-
                 var path = [
                     new google.maps.LatLng(start_lat, start_lng),
                     new google.maps.LatLng(end_lat, end_lng)
@@ -460,19 +456,8 @@
                     map: map
                 });
 
-                google.maps.event.addListener(line, 'mouseover', function(event) {
-                    line.setOptions({strokeWeight: 4, strokeOpacity: 0.8});
-                    infowindow.open(map);
-                    infowindow.setPosition(event.latLng);
-                });
-
                 google.maps.event.addListener(line, 'dblclick', function(event) {
                     window.location.href = url;
-                });
-
-                google.maps.event.addListener(line, 'mouseout', function() {
-                    line.setOptions({strokeWeight: 2, strokeOpacity: 0.5});
-                    infowindow.close();
                 });
             }
         });

--- a/src/niweb/apps/noclook/templates/noclook/google_maps.html
+++ b/src/niweb/apps/noclook/templates/noclook/google_maps.html
@@ -11,7 +11,7 @@
     <title>NOCLook Google Maps</title>
 {% load noclook_tags %}
 <script type="text/javascript" src="{% static "js/jquery/jquery-3.3.1.min.js" %}"></script>
-<script src="https://maps.googleapis.com/maps/api/js?v=3&sensor=false&key={{ maps_api_key }}" type="text/javascript"></script>
+<script src="https://maps.googleapis.com/maps/api/js?v=3&sensor=false&libraries=geometry&key={{ maps_api_key }}" type="text/javascript"></script>
 <script type="text/javascript">
     function initialize() {
         var latlng = new google.maps.LatLng(59, 5);
@@ -24,13 +24,17 @@
         load_content(map)
     }
     function load_content(map) {
+        var allMarkers = [];
+        var allLabels = [];
+        
         $.getJSON('/gmaps/{{ slug }}.json', function(json) {
-            json.nodes.forEach(function(node) {
+            json.nodes.forEach(function(node, index) {
                 addMarker(
                         node.lat,
                         node.lng,
                         node.name,
-                        node.url
+                        node.url,
+                        index
                 );
             });
             json.edges.forEach(function(edge) {
@@ -48,26 +52,155 @@
                 }
             });
 
-            function addMarker(lat,lng,label,url){
+            function addMarker(lat,lng,label,url,index){
                 var latlng = new google.maps.LatLng(lat,lng);
 
                 var infowindow = new google.maps.InfoWindow({
-                    content: "<a href=\"" + url + "\">" + label + "</a>"
+                    content: "<div style='padding: 2px 4px; font-size: 12px;'><a href='" + url + "' style='text-decoration: none; color: #1a0dab; font-weight: 500;'>" + label + "</a></div>",
+                    disableAutoPan: true
+                });
+                
+                // Hide close button when opened
+                google.maps.event.addListener(infowindow, 'domready', function() {
+                    setTimeout(function() {
+                        var closeButtons = document.querySelectorAll('.gm-ui-hover-effect');
+                        closeButtons.forEach(function(btn) {
+                            btn.style.display = 'none';
+                        });
+                    }, 10);
                 });
 
                 var marker = new google.maps.Marker({
                     position: latlng,
-                    map: map
+                    map: map,
+                    icon: {
+                        path: google.maps.SymbolPath.CIRCLE,
+                        scale: 4,
+                        fillColor: "#FF0000",
+                        fillOpacity: 0.8,
+                        strokeColor: "#CC0000",
+                        strokeWeight: 1
+                    }
+                });
+                
+                allMarkers.push(marker);
+
+                // Calculate offset based on nearby markers - use alternating positions
+                var nearbyCount = 0;
+                var xOffset = 8;
+                var yOffset = -6;
+                
+                for (var i = 0; i < index; i++) {
+                    var otherMarker = allMarkers[i];
+                    var distance = google.maps.geometry.spherical.computeDistanceBetween(
+                        marker.getPosition(), 
+                        otherMarker.getPosition()
+                    );
+                    // If markers are very close (less than 500m), offset the label
+                    if (distance < 500) {
+                        nearbyCount++;
+                        // Alternate positions: right, below, left, above, then stack
+                        switch(nearbyCount % 4) {
+                            case 0: // right
+                                xOffset = 8;
+                                yOffset = -6 + Math.floor(nearbyCount/4) * 20;
+                                break;
+                            case 1: // below
+                                xOffset = 8;
+                                yOffset = 10 + Math.floor(nearbyCount/4) * 20;
+                                break;
+                            case 2: // left-below
+                                xOffset = -80;
+                                yOffset = 10 + Math.floor(nearbyCount/4) * 20;
+                                break;
+                            case 3: // right-above
+                                xOffset = 8;
+                                yOffset = -22 - Math.floor(nearbyCount/4) * 20;
+                                break;
+                        }
+                    }
+                }
+
+                // Create a custom label overlay
+                var labelOverlay = new google.maps.OverlayView();
+                labelOverlay.onAdd = function() {
+                    var div = document.createElement('div');
+                    div.style.position = 'absolute';
+                    div.style.display = 'none';
+                    div.style.pointerEvents = 'none';
+                    div.innerHTML = '<div style="background: rgba(255,255,255,0.95); padding: 3px 5px; border: 1px solid #333; border-radius: 3px; font-size: 11px; font-weight: bold; white-space: nowrap; box-shadow: 2px 2px 4px rgba(0,0,0,0.4);">' + label + '</div>';
+                    
+                    var panes = this.getPanes();
+                    panes.overlayLayer.appendChild(div);
+                    this.div = div;
+                };
+                
+                labelOverlay.draw = function() {
+                    var projection = this.getProjection();
+                    var position = projection.fromLatLngToDivPixel(marker.getPosition());
+                    var div = this.div;
+                    div.style.left = (position.x + xOffset) + 'px';
+                    div.style.top = (position.y + yOffset) + 'px';
+                };
+                
+                labelOverlay.onRemove = function() {
+                    if (this.div) {
+                        this.div.parentNode.removeChild(this.div);
+                        this.div = null;
+                    }
+                };
+                
+                labelOverlay.setMap(map);
+                allLabels.push(labelOverlay);
+
+                // Show/hide labels based on zoom level
+                function updateLabelVisibility() {
+                    var zoom = map.getZoom();
+                    if (zoom >= 8) {
+                        labelOverlay.div.style.display = 'block';
+                    } else {
+                        labelOverlay.div.style.display = 'none';
+                    }
+                }
+
+                // Update visibility on zoom change
+                google.maps.event.addListener(map, 'zoom_changed', updateLabelVisibility);
+                google.maps.event.addListener(map, 'bounds_changed', function() {
+                    if (labelOverlay.div) {
+                        labelOverlay.draw();
+                    }
+                });
+                
+                // Set initial visibility
+                setTimeout(updateLabelVisibility, 100);
+
+                google.maps.event.addListener(marker, 'mouseover', function() {
+                    infowindow.open(map, marker);
                 });
 
-                google.maps.event.addListener(marker, 'click', function() {
-                    infowindow.open(map, marker);
+                google.maps.event.addListener(marker, 'mouseout', function() {
+                    infowindow.close();
+                });
+
+                google.maps.event.addListener(marker, 'dblclick', function() {
+                    window.location.href = url;
                 });
             }
 
             function addLine(start_lat, start_lng, end_lat, end_lng, label, url){
                 var infowindow = new google.maps.InfoWindow({
-                    content: "Cable:<br /><a href=\"" + url + "\">" + label + "</a>"
+                    content: "<div style='padding: 2px 4px; font-size: 12px;'><span style='color: #666; font-size: 11px;'>Cable:</span><br/><a href='" + url + "' style='text-decoration: none; color: #1a0dab; font-weight: 500;'>" + label + "</a></div>",
+                    disableAutoPan: true
+                });
+                
+                // Hide close button when opened
+                google.maps.event.addListener(infowindow, 'domready', function() {
+                    setTimeout(function() {
+                        var closeButtons = document.querySelectorAll('.gm-ui-hover-effect');
+                        closeButtons.forEach(function(btn) {
+                            btn.style.display = 'none';
+                        });
+                    }, 10);
                 });
 
                 var path = [
@@ -84,16 +217,18 @@
                 });
 
                 google.maps.event.addListener(line, 'mouseover', function(event) {
-                    line.setOptions({strokeWeight: 4, strokeOpacity: 0.8})
+                    line.setOptions({strokeWeight: 4, strokeOpacity: 0.8});
+                    infowindow.open(map);
+                    infowindow.setPosition(event.latLng);
                 });
 
-                google.maps.event.addListener(line, 'click', function(event) {
-                    infowindow.open(map);
-                    infowindow.setPosition(event.latLng)
+                google.maps.event.addListener(line, 'dblclick', function(event) {
+                    window.location.href = url;
                 });
 
                 google.maps.event.addListener(line, 'mouseout', function() {
-                    line.setOptions({strokeWeight: 2, strokeOpacity: 0.5})
+                    line.setOptions({strokeWeight: 2, strokeOpacity: 0.5});
+                    infowindow.close();
                 });
             }
         });

--- a/src/niweb/apps/noclook/templates/noclook/google_maps.html
+++ b/src/niweb/apps/noclook/templates/noclook/google_maps.html
@@ -189,7 +189,7 @@
 
             function addLine(start_lat, start_lng, end_lat, end_lng, label, url){
                 var infowindow = new google.maps.InfoWindow({
-                    content: "<div style='padding: 2px 4px; font-size: 12px;'><span style='color: #666; font-size: 11px;'>Cable:</span><br/><a href='" + url + "' style='text-decoration: none; color: #1a0dab; font-weight: 500;'>" + label + "</a></div>",
+                    content: "<div style='padding: 2px 4px; font-size: 12px;'><span style='color: #666; font-size: 11px;'>Optical Link:</span><br/><a href='" + url + "' style='text-decoration: none; color: #1a0dab; font-weight: 500;'>" + label + "</a></div>",
                     disableAutoPan: true
                 });
                 

--- a/src/niweb/apps/noclook/templates/noclook/google_maps.html
+++ b/src/niweb/apps/noclook/templates/noclook/google_maps.html
@@ -276,8 +276,7 @@
         });
         
         // Now categorize ALL paths in availablePaths based on current node position
-        var ingressPaths = [];
-        var egressPaths = [];
+        var endpointPaths = [];
         var transitPaths = [];
         
         for (var pathKey in availablePaths) {
@@ -301,12 +300,9 @@
                 if (nodeIndex === -1) {
                     // Node not in path, skip this path
                     continue;
-                } else if (nodeIndex === 0) {
-                    // First node - ingress
-                    ingressPaths.push(path);
-                } else if (nodeIndex === path.nodes.length - 1) {
-                    // Last node - egress
-                    egressPaths.push(path);
+                } else if (nodeIndex === 0 || nodeIndex === path.nodes.length - 1) {
+                    // First or last node - endpoint
+                    endpointPaths.push(path);
                 } else {
                     // Middle node - transit
                     transitPaths.push(path);
@@ -338,29 +334,15 @@
             return itemHtml;
         }
         
-        // Ingress section
-        if (ingressPaths.length > 0) {
+        // Endpoint section
+        if (endpointPaths.length > 0) {
             html += '<div class="path-section">';
-            html += '<div class="path-section-header" onclick="toggleSection(\'ingress\')">';
-            html += '<span>Ingress <span class="path-count">(' + ingressPaths.length + ')</span></span>';
+            html += '<div class="path-section-header" onclick="toggleSection(\'endpoint\')">';
+            html += '<span>Endpoint <span class="path-count">(' + endpointPaths.length + ')</span></span>';
             html += '<span class="toggle-icon">▼</span>';
             html += '</div>';
-            html += '<div class="path-section-content" id="ingress-section">';
-            ingressPaths.forEach(function(path) {
-                html += buildPathItem(path);
-            });
-            html += '</div></div>';
-        }
-        
-        // Egress section
-        if (egressPaths.length > 0) {
-            html += '<div class="path-section">';
-            html += '<div class="path-section-header" onclick="toggleSection(\'egress\')">';
-            html += '<span>Egress <span class="path-count">(' + egressPaths.length + ')</span></span>';
-            html += '<span class="toggle-icon">▼</span>';
-            html += '</div>';
-            html += '<div class="path-section-content" id="egress-section">';
-            egressPaths.forEach(function(path) {
+            html += '<div class="path-section-content" id="endpoint-section">';
+            endpointPaths.forEach(function(path) {
                 html += buildPathItem(path);
             });
             html += '</div></div>';

--- a/src/niweb/apps/noclook/templates/noclook/google_maps.html
+++ b/src/niweb/apps/noclook/templates/noclook/google_maps.html
@@ -18,6 +18,41 @@
         box-sizing: border-box;
       }
       #path_panel h3 { margin-top: 0; }
+      .path-section {
+        margin-bottom: 15px;
+      }
+      .path-section-header {
+        background: #e8e8e8;
+        padding: 8px 10px;
+        border-radius: 4px;
+        cursor: pointer;
+        font-weight: 600;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        user-select: none;
+      }
+      .path-section-header:hover {
+        background: #d8d8d8;
+      }
+      .path-section-header .toggle-icon {
+        transition: transform 0.2s;
+      }
+      .path-section-header.collapsed .toggle-icon {
+        transform: rotate(-90deg);
+      }
+      .path-section-content {
+        margin-top: 8px;
+        display: block;
+      }
+      .path-section-content.collapsed {
+        display: none;
+      }
+      .path-count {
+        font-size: 0.9em;
+        color: #666;
+        font-weight: normal;
+      }
       .path-item {
         margin-bottom: 10px;
         padding: 8px;
@@ -123,11 +158,16 @@
                                 // Mark as selected
                                 selectedPaths[pathKey] = true;
                                 
-                                // Add to UI
+                                // Add to UI - wrap in a preloaded section
                                 var colorIndicator = '<span class="path-color-indicator" style="background-color:' + availablePaths[pathKey].color + '"></span>';
                                 var pathUrl = '/optical-path/' + targetPath.id + '/';
                                 
-                                var pathListHtml = '<div class="path-item">';
+                                var pathListHtml = '<div class="path-section">';
+                                pathListHtml += '<div class="path-section-header">';
+                                pathListHtml += '<span>Preloaded Path <span class="path-count">(1)</span></span>';
+                                pathListHtml += '</div>';
+                                pathListHtml += '<div class="path-section-content">';
+                                pathListHtml += '<div class="path-item">';
                                 pathListHtml += '<label>';
                                 pathListHtml += '<input type="checkbox" class="path-checkbox" data-path-key="' + pathKey + '" checked>';
                                 pathListHtml += colorIndicator;
@@ -138,6 +178,7 @@
                                 pathListHtml += '<br><small>State: ' + targetPath.operational_state + '</small>';
                                 pathListHtml += '</label>';
                                 pathListHtml += '</div>';
+                                pathListHtml += '</div></div>';
                                 
                                 $('#path_list').append(pathListHtml);
                                 
@@ -211,57 +252,145 @@
     }
     
     function displayOpticalPaths(paths, nodeHandleId) {
-        // Remove unchecked paths from previous selection
+        // Save checked state and remove unchecked paths from availablePaths
         $('.path-item').each(function() {
             var checkbox = $(this).find('.path-checkbox');
             var pathKey = checkbox.data('path-key');
             
-            // If the path is not currently selected/checked, remove it
+            // If the path is not currently selected/checked, remove it from availablePaths
             if (!checkbox.is(':checked')) {
-                $(this).remove();
                 delete availablePaths[pathKey];
             }
         });
         
-        var pathListHtml = '';
+        // Clear all path sections to rebuild them
+        $('.path-section').remove();
         
+        // Add new paths to availablePaths
         paths.forEach(function(path) {
-            // Use just the path ID as the key to avoid duplicates
             var pathKey = path.id.toString();
-            
-            // Skip if this path is already displayed (checked or not)
-            if ($('.path-checkbox[data-path-key="' + pathKey + '"]').length > 0) {
-                return; // Path already in the list, skip it
-            }
-            
-            // Store path data if not already stored
             if (!availablePaths[pathKey]) {
                 availablePaths[pathKey] = path;
                 availablePaths[pathKey].color = getNextColor();
             }
-            
-            var checked = selectedPaths[pathKey] ? 'checked' : '';
-            var colorIndicator = '<span class="path-color-indicator" style="background-color:' + availablePaths[pathKey].color + '"></span>';
-            
-            // Construct the optical path URL
-            var pathUrl = '/optical-path/' + path.id + '/';
-            
-            pathListHtml += '<div class="path-item">';
-            pathListHtml += '<label>';
-            pathListHtml += '<input type="checkbox" class="path-checkbox" data-path-key="' + pathKey + '" ' + checked + '>';
-            pathListHtml += colorIndicator;
-            pathListHtml += '<a href="' + pathUrl + '" target="_blank" style="text-decoration: none; color: #1a0dab; font-weight: 500;">' + path.name + '</a>';
-            if (path.description) {
-                pathListHtml += '<br><small>' + path.description + '</small>';
-            }
-            pathListHtml += '<br><small>State: ' + path.operational_state + '</small>';
-            pathListHtml += '</label>';
-            pathListHtml += '</div>';
         });
         
-        if (pathListHtml) {
-            $('#path_list').append(pathListHtml);
+        // Now categorize ALL paths in availablePaths based on current node position
+        var ingressPaths = [];
+        var egressPaths = [];
+        var transitPaths = [];
+        
+        for (var pathKey in availablePaths) {
+            if (!availablePaths.hasOwnProperty(pathKey)) continue;
+            
+            var path = availablePaths[pathKey];
+            
+            // Determine path type based on node position
+            if (path.nodes && path.nodes.length > 0) {
+                var currentNodeId = nodeHandleId.toString();
+                
+                // Check if current node is in the path
+                var nodeIndex = -1;
+                for (var i = 0; i < path.nodes.length; i++) {
+                    if (path.nodes[i].handle_id.toString() === currentNodeId) {
+                        nodeIndex = i;
+                        break;
+                    }
+                }
+                
+                if (nodeIndex === -1) {
+                    // Node not in path, skip this path
+                    continue;
+                } else if (nodeIndex === 0) {
+                    // First node - ingress
+                    ingressPaths.push(path);
+                } else if (nodeIndex === path.nodes.length - 1) {
+                    // Last node - egress
+                    egressPaths.push(path);
+                } else {
+                    // Middle node - transit
+                    transitPaths.push(path);
+                }
+            }
         }
+        
+        // Build HTML for each section
+        var html = '';
+        
+        // Helper function to build path item HTML
+        function buildPathItem(path) {
+            var pathKey = path.id.toString();
+            var checked = selectedPaths[pathKey] ? 'checked' : '';
+            var colorIndicator = '<span class="path-color-indicator" style="background-color:' + availablePaths[pathKey].color + '"></span>';
+            var pathUrl = '/optical-path/' + path.id + '/';
+            
+            var itemHtml = '<div class="path-item">';
+            itemHtml += '<label>';
+            itemHtml += '<input type="checkbox" class="path-checkbox" data-path-key="' + pathKey + '" ' + checked + '>';
+            itemHtml += colorIndicator;
+            itemHtml += '<a href="' + pathUrl + '" target="_blank" style="text-decoration: none; color: #1a0dab; font-weight: 500;">' + path.name + '</a>';
+            if (path.description) {
+                itemHtml += '<br><small>' + path.description + '</small>';
+            }
+            itemHtml += '<br><small>State: ' + path.operational_state + '</small>';
+            itemHtml += '</label>';
+            itemHtml += '</div>';
+            return itemHtml;
+        }
+        
+        // Ingress section
+        if (ingressPaths.length > 0) {
+            html += '<div class="path-section">';
+            html += '<div class="path-section-header" onclick="toggleSection(\'ingress\')">';
+            html += '<span>Ingress <span class="path-count">(' + ingressPaths.length + ')</span></span>';
+            html += '<span class="toggle-icon">▼</span>';
+            html += '</div>';
+            html += '<div class="path-section-content" id="ingress-section">';
+            ingressPaths.forEach(function(path) {
+                html += buildPathItem(path);
+            });
+            html += '</div></div>';
+        }
+        
+        // Egress section
+        if (egressPaths.length > 0) {
+            html += '<div class="path-section">';
+            html += '<div class="path-section-header" onclick="toggleSection(\'egress\')">';
+            html += '<span>Egress <span class="path-count">(' + egressPaths.length + ')</span></span>';
+            html += '<span class="toggle-icon">▼</span>';
+            html += '</div>';
+            html += '<div class="path-section-content" id="egress-section">';
+            egressPaths.forEach(function(path) {
+                html += buildPathItem(path);
+            });
+            html += '</div></div>';
+        }
+        
+        // Transit section (collapsed by default)
+        if (transitPaths.length > 0) {
+            html += '<div class="path-section">';
+            html += '<div class="path-section-header collapsed" onclick="toggleSection(\'transit\')">';
+            html += '<span>Transit <span class="path-count">(' + transitPaths.length + ')</span></span>';
+            html += '<span class="toggle-icon">▼</span>';
+            html += '</div>';
+            html += '<div class="path-section-content collapsed" id="transit-section">';
+            transitPaths.forEach(function(path) {
+                html += buildPathItem(path);
+            });
+            html += '</div></div>';
+        }
+        
+        if (html) {
+            $('#path_list').append(html);
+        }
+    }
+    
+    function toggleSection(sectionId) {
+        var header = event.currentTarget;
+        var content = $('#' + sectionId + '-section');
+        
+        $(header).toggleClass('collapsed');
+        content.toggleClass('collapsed');
     }
     
    function drawOpticalPath(pathData, pathKey) {

--- a/src/niweb/apps/noclook/templates/noclook/google_maps.html
+++ b/src/niweb/apps/noclook/templates/noclook/google_maps.html
@@ -54,6 +54,14 @@
     var drawnPaths = [];
     var pathColors = ['#0066CC', '#CC6600', '#009900', '#CC0066', '#6600CC', '#00CC66', '#CCCC00', '#00CCCC'];
     var colorIndex = 0;
+    var pathToPreload = null; // Store path ID to preload after map loads
+    
+    function getUrlParameter(name) {
+        name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
+        var regex = new RegExp('[\\?&]' + name + '=([^&#]*)');
+        var results = regex.exec(location.search);
+        return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+    }
     
     function initialize() {
         var latlng = new google.maps.LatLng(59, 5);
@@ -81,7 +89,73 @@
             }
         });
         
+        // Check if there's a path parameter to preselect
+        pathToPreload = getUrlParameter('path');
+        
         load_content(map);
+    }
+    
+    function preloadOpticalPath(pathHandleId) {
+        // Try to find which optical node has this path by checking all markers
+        var foundPath = false;
+        var checkPromises = [];
+        
+        allMarkers.forEach(function(marker) {
+            // Extract handle_id from marker URL
+            var handleId = marker.nodeUrl.match(/\/(\d+)\/?$/);
+            if (handleId) {
+                var promise = $.getJSON('/gmaps/optical-paths/' + handleId[1] + '.json')
+                    .done(function(data) {
+                        if (!foundPath && data.paths) {
+                            // Look for our target path
+                            var targetPath = data.paths.find(function(p) {
+                                return p.id.toString() === pathHandleId;
+                            });
+                            
+                            if (targetPath) {
+                                foundPath = true;
+                                var pathKey = pathHandleId;
+                                
+                                // Add to available paths
+                                availablePaths[pathKey] = targetPath;
+                                availablePaths[pathKey].color = getNextColor();
+                                
+                                // Mark as selected
+                                selectedPaths[pathKey] = true;
+                                
+                                // Add to UI
+                                var colorIndicator = '<span class="path-color-indicator" style="background-color:' + availablePaths[pathKey].color + '"></span>';
+                                var pathUrl = '/optical-path/' + targetPath.id + '/';
+                                
+                                var pathListHtml = '<div class="path-item">';
+                                pathListHtml += '<label>';
+                                pathListHtml += '<input type="checkbox" class="path-checkbox" data-path-key="' + pathKey + '" checked>';
+                                pathListHtml += colorIndicator;
+                                pathListHtml += '<a href="' + pathUrl + '" target="_blank" style="text-decoration: none; color: #1a0dab; font-weight: 500;">' + targetPath.name + '</a>';
+                                if (targetPath.description) {
+                                    pathListHtml += '<br><small>' + targetPath.description + '</small>';
+                                }
+                                pathListHtml += '<br><small>State: ' + targetPath.operational_state + '</small>';
+                                pathListHtml += '</label>';
+                                pathListHtml += '</div>';
+                                
+                                $('#path_list').append(pathListHtml);
+                                
+                                // Draw the path on the map
+                                drawOpticalPath(targetPath, pathKey);
+                                
+                                // Center map on the first node of the path
+                                if (targetPath.nodes && targetPath.nodes.length > 0) {
+                                    var firstNode = targetPath.nodes[0];
+                                    map.setCenter(new google.maps.LatLng(firstNode.lat, firstNode.lng));
+                                    map.setZoom(7);
+                                }
+                            }
+                        }
+                    });
+                checkPromises.push(promise);
+            }
+        });
     }
     
     function redrawAllPaths() {
@@ -459,6 +533,11 @@
                 google.maps.event.addListener(line, 'dblclick', function(event) {
                     window.location.href = url;
                 });
+            }
+            
+            // After map content is fully loaded, check if we need to preload a specific path
+            if (pathToPreload) {
+                preloadOpticalPath(pathToPreload);
             }
         });
     }

--- a/src/niweb/apps/noclook/templates/noclook/google_maps.html
+++ b/src/niweb/apps/noclook/templates/noclook/google_maps.html
@@ -6,13 +6,55 @@
     <style type="text/css">
       html { height: 100% }
       body { height: 100%; margin: 0; padding: 0 }
-      #map_canvas { height: 100% }
+      #map_canvas { height: 100%; width: calc(100% - 300px); float: left; }
+      #path_panel { 
+        width: 300px;
+        height: 100%;
+        float: right;
+        background: white;
+        border-left: 2px solid #ccc;
+        overflow-y: auto;
+        padding: 10px;
+        box-sizing: border-box;
+      }
+      #path_panel h3 { margin-top: 0; }
+      .path-item {
+        margin-bottom: 10px;
+        padding: 8px;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        background: #f9f9f9;
+      }
+      .path-item label { cursor: pointer; display: block; }
+      .path-item input[type="checkbox"] { margin-right: 8px; }
+      .path-color-indicator {
+        display: inline-block;
+        width: 20px;
+        height: 3px;
+        margin-right: 5px;
+        vertical-align: middle;
+      }
+      .node-selected-label {
+        font-weight: bold;
+        color: #0066cc;
+        margin-bottom: 10px;
+      }
     </style>
     <title>NOCLook Google Maps</title>
 {% load noclook_tags %}
 <script type="text/javascript" src="{% static "js/jquery/jquery-3.3.1.min.js" %}"></script>
 <script src="https://maps.googleapis.com/maps/api/js?v=3&sensor=false&libraries=geometry&key={{ maps_api_key }}" type="text/javascript"></script>
 <script type="text/javascript">
+    var map;
+    var allMarkers = [];
+    var allLabels = [];
+    var selectedNode = null;
+    var availablePaths = {};
+    var selectedPaths = {};
+    var drawnPaths = [];
+    var pathColors = ['#0066CC', '#CC6600', '#009900', '#CC0066', '#6600CC', '#00CC66', '#CCCC00', '#00CCCC'];
+    var colorIndex = 0;
+    
     function initialize() {
         var latlng = new google.maps.LatLng(59, 5);
         var myOptions = {
@@ -20,12 +62,202 @@
             center: latlng,
             mapTypeId: google.maps.MapTypeId.ROADMAP
         };
-        var map = new google.maps.Map(document.getElementById("map_canvas"), myOptions);
-        load_content(map)
+        map = new google.maps.Map(document.getElementById("map_canvas"), myOptions);
+        
+        // Redraw paths when zoom level changes
+        google.maps.event.addListener(map, 'zoom_changed', function() {
+            redrawAllPaths();
+        });
+        
+        load_content(map);
     }
+    
+    function redrawAllPaths() {
+        // Remove all current path polylines
+        drawnPaths.forEach(function(item) {
+            item.polyline.setMap(null);
+        });
+        drawnPaths = [];
+        
+        // Redraw all selected paths with new zoom-based offsets
+        for (var pathKey in selectedPaths) {
+            if (selectedPaths.hasOwnProperty(pathKey) && availablePaths[pathKey]) {
+                drawOpticalPath(availablePaths[pathKey], pathKey);
+            }
+        }
+    }
+    
+    function getNextColor() {
+        var color = pathColors[colorIndex % pathColors.length];
+        colorIndex++;
+        return color;
+    }
+    
+    function selectNode(nodeHandleId, nodeName, marker) {
+        // Update selected node marker color
+        if (selectedNode && selectedNode.marker) {
+            selectedNode.marker.setIcon({
+                path: google.maps.SymbolPath.CIRCLE,
+                scale: 4,
+                fillColor: "#FF0000",
+                fillOpacity: 0.8,
+                strokeColor: "#CC0000",
+                strokeWeight: 1
+            });
+        }
+        
+        selectedNode = {handle_id: nodeHandleId, name: nodeName, marker: marker};
+        marker.setIcon({
+            path: google.maps.SymbolPath.CIRCLE,
+            scale: 6,
+            fillColor: "#0066CC",
+            fillOpacity: 1.0,
+            strokeColor: "#003366",
+            strokeWeight: 2
+        });
+        
+        $('#selected_node_name').text(nodeName);
+        
+        // Fetch optical paths for this node
+        $.getJSON('/gmaps/optical-paths/' + nodeHandleId + '.json', function(data) {
+            displayOpticalPaths(data.paths, nodeHandleId);
+        });
+    }
+    
+    function displayOpticalPaths(paths, nodeHandleId) {
+        // Remove unchecked paths from previous selection
+        $('.path-item').each(function() {
+            var checkbox = $(this).find('.path-checkbox');
+            var pathKey = checkbox.data('path-key');
+            
+            // If the path is not currently selected/checked, remove it
+            if (!checkbox.is(':checked')) {
+                $(this).remove();
+                delete availablePaths[pathKey];
+            }
+        });
+        
+        var pathListHtml = '';
+        
+        paths.forEach(function(path) {
+            var pathKey = nodeHandleId + '_' + path.id;
+            
+            // Store path data if not already stored
+            if (!availablePaths[pathKey]) {
+                availablePaths[pathKey] = path;
+                availablePaths[pathKey].color = getNextColor();
+            }
+            
+            var checked = selectedPaths[pathKey] ? 'checked' : '';
+            var colorIndicator = '<span class="path-color-indicator" style="background-color:' + availablePaths[pathKey].color + '"></span>';
+            
+            pathListHtml += '<div class="path-item">';
+            pathListHtml += '<label>';
+            pathListHtml += '<input type="checkbox" class="path-checkbox" data-path-key="' + pathKey + '" ' + checked + '>';
+            pathListHtml += colorIndicator;
+            pathListHtml += '<strong>' + path.name + '</strong>';
+            if (path.description) {
+                pathListHtml += '<br><small>' + path.description + '</small>';
+            }
+            pathListHtml += '<br><small>State: ' + path.operational_state + '</small>';
+            pathListHtml += '</label>';
+            pathListHtml += '</div>';
+        });
+        
+        $('#path_list').append(pathListHtml);
+        
+        // Add checkbox handlers
+        $('.path-checkbox').on('change', function() {
+            var pathKey = $(this).data('path-key');
+            if ($(this).is(':checked')) {
+                selectedPaths[pathKey] = true;
+                drawOpticalPath(availablePaths[pathKey], pathKey);
+            } else {
+                delete selectedPaths[pathKey];
+                removeOpticalPath(pathKey);
+            }
+        });
+    }
+    
+   function drawOpticalPath(pathData, pathKey) {
+        pathKey = pathKey || (pathData.handle_id || pathData.id);
+        var nodes = pathData.nodes;
+        
+        if (nodes.length < 2) return;
+        
+        for (var i = 0; i < nodes.length - 1; i++) {
+            var start = nodes[i];
+            var end = nodes[i + 1];
+            
+            var startLatLng = new google.maps.LatLng(start.lat, start.lng);
+            var endLatLng = new google.maps.LatLng(end.lat, end.lng);
+            
+            // Calculate offset for this specific segment
+            var offset = calculateSegmentOffset(start.handle_id, end.handle_id, pathKey);
+            
+            // Apply offset perpendicular to the line (parallel offset for both points)
+            if (offset !== 0) {
+                var heading = google.maps.geometry.spherical.computeHeading(startLatLng, endLatLng);
+                var perpendicular = heading + 90;
+                startLatLng = google.maps.geometry.spherical.computeOffset(startLatLng, offset, perpendicular);
+                endLatLng = google.maps.geometry.spherical.computeOffset(endLatLng, offset, perpendicular);
+            }
+            
+            var path = new google.maps.Polyline({
+                path: [startLatLng, endLatLng],
+                strokeWeight: 5,
+                strokeColor: pathData.color,
+                strokeOpacity: 0.9,
+                map: map
+            });
+            
+            drawnPaths.push({
+                pathKey: pathKey, 
+                polyline: path,
+                startNodeId: start.handle_id,
+                endNodeId: end.handle_id
+            });
+        }
+    }
+    
+    function calculateSegmentOffset(startNodeId, endNodeId, currentPathKey) {
+        // Count how many paths already use this segment (in either direction)
+        var segmentPaths = drawnPaths.filter(function(p) {
+            return (p.startNodeId === startNodeId && p.endNodeId === endNodeId) ||
+                   (p.startNodeId === endNodeId && p.endNodeId === startNodeId);
+        });
+        
+        // Calculate offset based on position among parallel paths
+        var pathIndex = segmentPaths.length;
+        
+        // Calculate offset to ensure lines never overlap
+        // Line width is 5 pixels, we need at least 6 pixels separation for visibility
+        var currentZoom = map.getZoom();
+        var pixelSeparation = 6; // pixels between line centers
+        
+        // Calculate meters per pixel at current zoom level (at equator, approximate for latitude ~60)
+        var metersPerPixel = 156543.03392 * Math.cos(60 * Math.PI / 180) / Math.pow(2, currentZoom);
+        var offsetDistance = pixelSeparation * metersPerPixel;
+        
+        // Distribute paths evenly on both sides of the center line
+        if (pathIndex === 0) return 0;
+        var side = (pathIndex % 2 === 0) ? 1 : -1;
+        var magnitude = Math.ceil(pathIndex / 2);
+        
+        return side * magnitude * offsetDistance;
+    }
+    
+    function removeOpticalPath(pathKey) {
+        drawnPaths = drawnPaths.filter(function(item) {
+            if (item.pathKey == pathKey) {
+                item.polyline.setMap(null);
+                return false;
+            }
+            return true;
+        });
+    }
+    
     function load_content(map) {
-        var allMarkers = [];
-        var allLabels = [];
         
         $.getJSON('/gmaps/{{ slug }}.json', function(json) {
             json.nodes.forEach(function(node, index) {
@@ -82,6 +314,10 @@
                         strokeWeight: 1
                     }
                 });
+                
+                // Store metadata on marker
+                marker.nodeUrl = url;
+                marker.nodeName = label;
                 
                 allMarkers.push(marker);
 
@@ -182,6 +418,14 @@
                     infowindow.close();
                 });
 
+                google.maps.event.addListener(marker, 'click', function() {
+                    // Extract handle_id from URL
+                    var handleId = url.match(/\/(\d+)\/?$/);
+                    if (handleId) {
+                        selectNode(handleId[1], label, marker);
+                    }
+                });
+
                 google.maps.event.addListener(marker, 'dblclick', function() {
                     window.location.href = url;
                 });
@@ -236,6 +480,13 @@
 </script>
 </head>
 <body onload="initialize()">
-  <div id="map_canvas" style="width:100%; height:100%"></div>
+  <div id="map_canvas"></div>
+  <div id="path_panel">
+    <h3>Optical Path Selector</h3>
+    <div class="node-selected-label">
+      Selected Node: <span id="selected_node_name">None</span>
+    </div>
+    <div id="path_list"></div>
+  </div>
 </body>
 </html>

--- a/src/niweb/apps/noclook/templates/noclook/google_maps.html
+++ b/src/niweb/apps/noclook/templates/noclook/google_maps.html
@@ -159,26 +159,27 @@
                                 selectedPaths[pathKey] = true;
                                 
                                 // Add to UI - wrap in a preloaded section
-                                var colorIndicator = '<span class="path-color-indicator" style="background-color:' + availablePaths[pathKey].color + '"></span>';
                                 var pathUrl = '/optical-path/' + targetPath.id + '/';
+                                var descriptionHtml = targetPath.description ? `<br><small>${targetPath.description}</small>` : '';
                                 
-                                var pathListHtml = '<div class="path-section">';
-                                pathListHtml += '<div class="path-section-header">';
-                                pathListHtml += '<span>Preloaded Path <span class="path-count">(1)</span></span>';
-                                pathListHtml += '</div>';
-                                pathListHtml += '<div class="path-section-content">';
-                                pathListHtml += '<div class="path-item">';
-                                pathListHtml += '<label>';
-                                pathListHtml += '<input type="checkbox" class="path-checkbox" data-path-key="' + pathKey + '" checked>';
-                                pathListHtml += colorIndicator;
-                                pathListHtml += '<a href="' + pathUrl + '" target="_blank" style="text-decoration: none; color: #1a0dab; font-weight: 500;">' + targetPath.name + '</a>';
-                                if (targetPath.description) {
-                                    pathListHtml += '<br><small>' + targetPath.description + '</small>';
-                                }
-                                pathListHtml += '<br><small>State: ' + targetPath.operational_state + '</small>';
-                                pathListHtml += '</label>';
-                                pathListHtml += '</div>';
-                                pathListHtml += '</div></div>';
+                                var pathListHtml = `
+                                    <div class="path-section">
+                                        <div class="path-section-header">
+                                            <span>Preloaded Path <span class="path-count">(1)</span></span>
+                                        </div>
+                                        <div class="path-section-content">
+                                            <div class="path-item">
+                                                <label>
+                                                    <input type="checkbox" class="path-checkbox" data-path-key="${pathKey}" checked>
+                                                    <span class="path-color-indicator" style="background-color:${availablePaths[pathKey].color}"></span>
+                                                    <a href="${pathUrl}" target="_blank" style="text-decoration: none; color: #1a0dab; font-weight: 500;">${targetPath.name}</a>
+                                                    ${descriptionHtml}
+                                                    <br><small>State: ${targetPath.operational_state}</small>
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div>
+                                `;
                                 
                                 $('#path_list').append(pathListHtml);
                                 
@@ -317,49 +318,52 @@
         function buildPathItem(path) {
             var pathKey = path.id.toString();
             var checked = selectedPaths[pathKey] ? 'checked' : '';
-            var colorIndicator = '<span class="path-color-indicator" style="background-color:' + availablePaths[pathKey].color + '"></span>';
             var pathUrl = '/optical-path/' + path.id + '/';
+            var descriptionHtml = path.description ? `<br><small>${path.description}</small>` : '';
             
-            var itemHtml = '<div class="path-item">';
-            itemHtml += '<label>';
-            itemHtml += '<input type="checkbox" class="path-checkbox" data-path-key="' + pathKey + '" ' + checked + '>';
-            itemHtml += colorIndicator;
-            itemHtml += '<a href="' + pathUrl + '" target="_blank" style="text-decoration: none; color: #1a0dab; font-weight: 500;">' + path.name + '</a>';
-            if (path.description) {
-                itemHtml += '<br><small>' + path.description + '</small>';
-            }
-            itemHtml += '<br><small>State: ' + path.operational_state + '</small>';
-            itemHtml += '</label>';
-            itemHtml += '</div>';
-            return itemHtml;
+            return `
+                <div class="path-item">
+                    <label>
+                        <input type="checkbox" class="path-checkbox" data-path-key="${pathKey}" ${checked}>
+                        <span class="path-color-indicator" style="background-color:${availablePaths[pathKey].color}"></span>
+                        <a href="${pathUrl}" target="_blank" style="text-decoration: none; color: #1a0dab; font-weight: 500;">${path.name}</a>
+                        ${descriptionHtml}
+                        <br><small>State: ${path.operational_state}</small>
+                    </label>
+                </div>
+            `;
         }
         
         // Endpoint section
         if (endpointPaths.length > 0) {
-            html += '<div class="path-section">';
-            html += '<div class="path-section-header" onclick="toggleSection(\'endpoint\')">';
-            html += '<span>Endpoint <span class="path-count">(' + endpointPaths.length + ')</span></span>';
-            html += '<span class="toggle-icon">▼</span>';
-            html += '</div>';
-            html += '<div class="path-section-content" id="endpoint-section">';
-            endpointPaths.forEach(function(path) {
-                html += buildPathItem(path);
-            });
-            html += '</div></div>';
+            var endpointItems = endpointPaths.map(buildPathItem).join('');
+            html += `
+                <div class="path-section">
+                    <div class="path-section-header" onclick="toggleSection('endpoint')">
+                        <span>Endpoint <span class="path-count">(${endpointPaths.length})</span></span>
+                        <span class="toggle-icon">▼</span>
+                    </div>
+                    <div class="path-section-content" id="endpoint-section">
+                        ${endpointItems}
+                    </div>
+                </div>
+            `;
         }
         
         // Transit section (collapsed by default)
         if (transitPaths.length > 0) {
-            html += '<div class="path-section">';
-            html += '<div class="path-section-header collapsed" onclick="toggleSection(\'transit\')">';
-            html += '<span>Transit <span class="path-count">(' + transitPaths.length + ')</span></span>';
-            html += '<span class="toggle-icon">▼</span>';
-            html += '</div>';
-            html += '<div class="path-section-content collapsed" id="transit-section">';
-            transitPaths.forEach(function(path) {
-                html += buildPathItem(path);
-            });
-            html += '</div></div>';
+            var transitItems = transitPaths.map(buildPathItem).join('');
+            html += `
+                <div class="path-section">
+                    <div class="path-section-header collapsed" onclick="toggleSection('transit')">
+                        <span>Transit <span class="path-count">(${transitPaths.length})</span></span>
+                        <span class="toggle-icon">▼</span>
+                    </div>
+                    <div class="path-section-content collapsed" id="transit-section">
+                        ${transitItems}
+                    </div>
+                </div>
+            `;
         }
         
         if (html) {
@@ -484,7 +488,7 @@
                 var latlng = new google.maps.LatLng(lat,lng);
 
                 var infowindow = new google.maps.InfoWindow({
-                    content: "<div style='padding: 2px 4px; font-size: 12px;'><a href='" + url + "' style='text-decoration: none; color: #1a0dab; font-weight: 500;'>" + label + "</a></div>",
+                    content: `<div style='padding: 2px 4px; font-size: 12px;'><a href='${url}' style='text-decoration: none; color: #1a0dab; font-weight: 500;'>${label}</a></div>`,
                     disableAutoPan: true
                 });
                 
@@ -560,7 +564,11 @@
                     div.style.position = 'absolute';
                     div.style.display = 'none';
                     div.style.pointerEvents = 'none';
-                    div.innerHTML = '<div style="background: rgba(255,255,255,0.95); padding: 3px 5px; border: 1px solid #333; border-radius: 3px; font-size: 11px; font-weight: bold; white-space: nowrap; box-shadow: 2px 2px 4px rgba(0,0,0,0.4);">' + label + '</div>';
+                    div.innerHTML = `
+                        <div style="background: rgba(255,255,255,0.95); padding: 3px 5px; border: 1px solid #333; border-radius: 3px; font-size: 11px; font-weight: bold; white-space: nowrap; box-shadow: 2px 2px 4px rgba(0,0,0,0.4);">
+                            ${label}
+                        </div>
+                    `;
                     
                     var panes = this.getPanes();
                     panes.overlayLayer.appendChild(div);

--- a/src/niweb/apps/noclook/urls.py
+++ b/src/niweb/apps/noclook/urls.py
@@ -134,6 +134,7 @@ urlpatterns = [
     path('service/<int:handle_id>/', detail.service_detail),
     path('optical-link/<int:handle_id>/', detail.optical_link_detail),
     path('optical-path/<int:handle_id>/', detail.optical_path_detail),
+    path('optical-path/<int:handle_id>/kmz/', other.optical_path_kmz),
     path('end-user/<int:handle_id>/', detail.end_user_detail),
     path('customer/<int:handle_id>/', detail.customer_detail),
     path('provider/<int:handle_id>/', detail.provider_detail),

--- a/src/niweb/apps/noclook/urls.py
+++ b/src/niweb/apps/noclook/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     # Google maps views
     path('gmaps/<slug>.json', other.gmaps_json),
     path('gmaps/<slug>/', other.gmaps),
+    path('gmaps/optical-paths/<node_handle_id>.json', other.gmaps_optical_paths),
     # Get all
     # TODO: can it be switched to path instead
     # Or are they even used?, cannot find anything on getall and findall

--- a/src/niweb/apps/noclook/views/other.py
+++ b/src/niweb/apps/noclook/views/other.py
@@ -11,6 +11,7 @@ from re import escape as re_escape
 import json
 import zipfile
 from io import BytesIO
+from xml.sax.saxutils import escape as xml_escape
 
 from apps.noclook.models import NodeHandle, NodeType
 from apps.noclook import arborgraph
@@ -625,9 +626,9 @@ def optical_path_kmz(request, handle_id):
     kml = '<?xml version="1.0" encoding="UTF-8"?>\n'
     kml += '<kml xmlns="http://www.opengis.net/kml/2.2">\n'
     kml += '<Document>\n'
-    kml += f'<name>{path_name}</name>\n'
+    kml += f'<name>{xml_escape(path_name)}</name>\n'
     if path_description:
-        kml += f'<description>{path_description}</description>\n'
+        kml += f'<description>{xml_escape(path_description)}</description>\n'
     
     # Add line style
     kml += '<Style id="pathLine">\n'
@@ -641,11 +642,12 @@ def optical_path_kmz(request, handle_id):
     for node_data in ordered_nodes:
         node_name = node_data['node']['name']
         site = node_data['site']
-        lng = float(str(site.get('longitude', 0)))
-        lat = float(str(site.get('latitude', 0)))
+        # Round coordinates to 3 decimal places (~111m precision) for security
+        lng = round(float(str(site.get('longitude', 0))), 3)
+        lat = round(float(str(site.get('latitude', 0))), 3)
         
         kml += '<Placemark>\n'
-        kml += f'<name>{node_name}</name>\n'
+        kml += f'<name>{xml_escape(node_name)}</name>\n'
         kml += '<Point>\n'
         kml += f'<coordinates>{lng},{lat},0</coordinates>\n'
         kml += '</Point>\n'
@@ -653,14 +655,15 @@ def optical_path_kmz(request, handle_id):
     
     # Add the path line
     kml += '<Placemark>\n'
-    kml += f'<name>{path_name} Path</name>\n'
+    kml += f'<name>{xml_escape(path_name)} Path</name>\n'
     kml += '<styleUrl>#pathLine</styleUrl>\n'
     kml += '<LineString>\n'
     kml += '<coordinates>\n'
     for node_data in ordered_nodes:
         site = node_data['site']
-        lng = float(str(site.get('longitude', 0)))
-        lat = float(str(site.get('latitude', 0)))
+        # Round coordinates to 3 decimal places (~111m precision) for security
+        lng = round(float(str(site.get('longitude', 0))), 3)
+        lat = round(float(str(site.get('latitude', 0))), 3)
         kml += f'{lng},{lat},0\n'
     kml += '</coordinates>\n'
     kml += '</LineString>\n'

--- a/src/niweb/apps/noclook/views/other.py
+++ b/src/niweb/apps/noclook/views/other.py
@@ -9,6 +9,8 @@ from django.shortcuts import get_object_or_404, render, redirect
 from django.conf import settings
 from re import escape as re_escape
 import json
+import zipfile
+from io import BytesIO
 
 from apps.noclook.models import NodeHandle, NodeType
 from apps.noclook import arborgraph
@@ -530,6 +532,153 @@ def gmaps_optical_paths(request, node_handle_id):
     
     response = HttpResponse(content_type='application/json')
     json.dump({'paths': paths}, response)
+    return response
+
+
+@login_required
+def optical_path_kmz(request, handle_id):
+    """
+    Generate and download a KMZ file for an optical path.
+    """
+    # Get the optical path
+    nh = get_object_or_404(NodeHandle, pk=handle_id)
+    path_node = nh.get_node()
+    
+    # Query to get all nodes in the optical path
+    q = """
+        MATCH (path:Optical_Path)
+        WHERE path.handle_id = $handle_id
+        MATCH (path)-[:Depends_on]->(oms:Optical_Multiplex_Section)
+        -[:Depends_on]->(link:Optical_Link)
+        -[:Depends_on]->(p:Port)<-[:Has]-(on:Optical_Node)
+        WITH path, oms, link, on
+        MATCH (on)-[:Located_in]->()<-[:Has*0..]-(loc:Site)
+        WITH path, oms.name as oms_name, link.name as link_name, on, loc
+        ORDER BY oms_name, link_name
+        WITH path, collect({node: on, site: loc, oms: oms_name, link: link_name}) as all_nodes
+        RETURN path, all_nodes
+        """
+    result = nc.query_to_list(nc.graphdb.manager, q, handle_id=int(handle_id))
+    
+    if not result:
+        raise Http404("Optical path not found or has no nodes")
+    
+    item = result[0]
+    all_nodes_data = item['all_nodes']
+    
+    # Build ordered path using the same logic as gmaps_optical_paths
+    adjacency = {}
+    node_lookup = {}
+    links_dict = {}
+    
+    for node_data in all_nodes_data:
+        link_name = node_data['link']
+        node_id = node_data['node']['handle_id']
+        
+        if link_name not in links_dict:
+            links_dict[link_name] = []
+        links_dict[link_name].append(node_data)
+        node_lookup[node_id] = node_data
+    
+    # Build adjacency list
+    for link_name, link_nodes in links_dict.items():
+        if len(link_nodes) == 2:
+            node1_id = link_nodes[0]['node']['handle_id']
+            node2_id = link_nodes[1]['node']['handle_id']
+            
+            if node1_id not in adjacency:
+                adjacency[node1_id] = []
+            if node2_id not in adjacency:
+                adjacency[node2_id] = []
+            
+            adjacency[node1_id].append((node2_id, link_name))
+            adjacency[node2_id].append((node1_id, link_name))
+    
+    # Find start node
+    endpoints = [nid for nid, neighbors in adjacency.items() if len(neighbors) == 1]
+    start_node = endpoints[0] if endpoints else list(adjacency.keys())[0] if adjacency else None
+    
+    if not start_node:
+        raise Http404("Cannot determine path sequence")
+    
+    # Traverse path
+    ordered_nodes = []
+    visited = set()
+    
+    def dfs(node_id):
+        if node_id in visited:
+            return
+        visited.add(node_id)
+        ordered_nodes.append(node_lookup[node_id])
+        
+        if node_id in adjacency:
+            for neighbor_id, _ in adjacency[node_id]:
+                if neighbor_id not in visited:
+                    dfs(neighbor_id)
+    
+    dfs(start_node)
+    
+    # Generate KML
+    path_name = item['path']['name']
+    path_description = item['path'].get('description', '')
+    
+    kml = '<?xml version="1.0" encoding="UTF-8"?>\n'
+    kml += '<kml xmlns="http://www.opengis.net/kml/2.2">\n'
+    kml += '<Document>\n'
+    kml += f'<name>{path_name}</name>\n'
+    if path_description:
+        kml += f'<description>{path_description}</description>\n'
+    
+    # Add line style
+    kml += '<Style id="pathLine">\n'
+    kml += '<LineStyle>\n'
+    kml += '<color>ff0000ff</color>\n'  # Red color
+    kml += '<width>4</width>\n'
+    kml += '</LineStyle>\n'
+    kml += '</Style>\n'
+    
+    # Add placemarks for each node
+    for node_data in ordered_nodes:
+        node_name = node_data['node']['name']
+        site = node_data['site']
+        lng = float(str(site.get('longitude', 0)))
+        lat = float(str(site.get('latitude', 0)))
+        
+        kml += '<Placemark>\n'
+        kml += f'<name>{node_name}</name>\n'
+        kml += '<Point>\n'
+        kml += f'<coordinates>{lng},{lat},0</coordinates>\n'
+        kml += '</Point>\n'
+        kml += '</Placemark>\n'
+    
+    # Add the path line
+    kml += '<Placemark>\n'
+    kml += f'<name>{path_name} Path</name>\n'
+    kml += '<styleUrl>#pathLine</styleUrl>\n'
+    kml += '<LineString>\n'
+    kml += '<coordinates>\n'
+    for node_data in ordered_nodes:
+        site = node_data['site']
+        lng = float(str(site.get('longitude', 0)))
+        lat = float(str(site.get('latitude', 0)))
+        kml += f'{lng},{lat},0\n'
+    kml += '</coordinates>\n'
+    kml += '</LineString>\n'
+    kml += '</Placemark>\n'
+    
+    kml += '</Document>\n'
+    kml += '</kml>\n'
+    
+    # Create KMZ (zipped KML)
+    kmz_buffer = BytesIO()
+    with zipfile.ZipFile(kmz_buffer, 'w', zipfile.ZIP_DEFLATED) as kmz:
+        kmz.writestr('doc.kml', kml.encode('utf-8'))
+    
+    # Prepare response
+    response = HttpResponse(kmz_buffer.getvalue(), content_type='application/vnd.google-earth.kmz')
+    filename = f'{path_name.replace(" ", "_")}.kmz'
+    response['Content-Disposition'] = f'attachment; filename="{filename}"'
+    
     return response
 
 

--- a/src/niweb/apps/noclook/views/other.py
+++ b/src/niweb/apps/noclook/views/other.py
@@ -355,7 +355,7 @@ def gmaps_sites(request):
 @login_required
 def gmaps_optical_nodes(request):
     """
-    Return a json object with dicts of optical node and cables.
+    Return a json object with dicts of optical nodes and optical links.
     {
     nodes: [
         {
@@ -373,19 +373,13 @@ def gmaps_optical_nodes(request):
         }
     ]
     """
-    # Cypher query to get all cables with cable type fiber that are connected
-    # to two optical node.
+    # Cypher query to get all optical links that connect optical nodes
     q = """
-        MATCH (cable:Cable)
-        WHERE cable.cable_type = "Dark Fiber"
-        MATCH (cable)-[Connected_to]->(port)
-        WITH cable, port
-        MATCH (port)<-[:Has*0..]-(equipment)
-        WHERE (equipment:Optical_Node) AND NOT equipment.type =~ "(?i).*tss.*"
-        WITH cable, port, equipment
-        MATCH p2=(equipment)-[:Located_in]->()<-[:Has*0..]-(loc)
+        MATCH (link:Optical_Link)-[:Depends_on]->(port:Port)<-[:Has]-(equipment:Optical_Node)
+        WITH link, equipment
+        MATCH (equipment)-[:Located_in]->()<-[:Has*0..]-(loc)
         WHERE (loc:Site)
-        RETURN cable, equipment, loc
+        RETURN link, equipment, loc
         """
     result = nc.query_to_list(nc.graphdb.manager, q)
     nodes = {}
@@ -402,15 +396,15 @@ def gmaps_optical_nodes(request):
             'lat': float(str(item['loc'].get('latitude', 0)))
         }
         edge = {
-            'name': item['cable']['name'],
-            'url': helpers.get_node_url(item['cable']['handle_id']),
+            'name': item['link']['name'],
+            'url': helpers.get_node_url(item['link']['handle_id']),
             'end_points': [coords]
         }
         nodes[item['equipment']['name']] = node
-        if item['cable']['name'] in edges:
-            edges[item['cable']['name']]['end_points'].append(coords)
+        if item['link']['name'] in edges:
+            edges[item['link']['name']]['end_points'].append(coords)
         else:
-            edges[item['cable']['name']] = edge
+            edges[item['link']['name']] = edge
     response = HttpResponse(content_type='application/json')
     json.dump({'nodes': list(nodes.values()), 'edges': list(edges.values())}, response)
     return response

--- a/src/niweb/apps/noclook/views/other.py
+++ b/src/niweb/apps/noclook/views/other.py
@@ -416,13 +416,20 @@ def gmaps_optical_paths(request, node_handle_id):
     Return optical paths that include the specified optical node.
     Returns JSON with path information and all the nodes in each path sequence.
     Only returns paths with operational_state = "In service".
+    Includes paths where the node is an endpoint or a transit node.
     """
     q = """
         MATCH (node:Optical_Node)
         WHERE node.handle_id = $handle_id
-        MATCH (node)-[:Has]->(port:Port)<-[:Depends_on]-(path:Optical_Path)
+        
+        // Find all paths that pass through this node via optical links
+        MATCH (node)-[:Has]->(port:Port)<-[:Depends_on]-(link:Optical_Link)
+        <-[:Depends_on]-(oms:Optical_Multiplex_Section)<-[:Depends_on]-(path:Optical_Path)
         WHERE path.operational_state = "In service"
-        WITH path
+        
+        WITH DISTINCT path
+        
+        // Get all nodes in each path
         MATCH (path)-[:Depends_on]->(oms:Optical_Multiplex_Section)
         -[:Depends_on]->(link:Optical_Link)
         -[:Depends_on]->(p:Port)<-[:Has]-(on:Optical_Node)

--- a/src/niweb/apps/noclook/views/other.py
+++ b/src/niweb/apps/noclook/views/other.py
@@ -411,6 +411,122 @@ def gmaps_optical_nodes(request):
 
 
 @login_required
+def gmaps_optical_paths(request, node_handle_id):
+    """
+    Return optical paths that include the specified optical node.
+    Returns JSON with path information and all the nodes in each path sequence.
+    Only returns paths with operational_state = "In service".
+    """
+    q = """
+        MATCH (node:Optical_Node)
+        WHERE node.handle_id = $handle_id
+        MATCH (node)-[:Has]->(port:Port)<-[:Depends_on]-(path:Optical_Path)
+        WHERE path.operational_state = "In service"
+        WITH path
+        MATCH (path)-[:Depends_on]->(oms:Optical_Multiplex_Section)
+        -[:Depends_on]->(link:Optical_Link)
+        -[:Depends_on]->(p:Port)<-[:Has]-(on:Optical_Node)
+        WITH path, oms, link, on
+        MATCH (on)-[:Located_in]->()<-[:Has*0..]-(loc:Site)
+        WITH path, oms.name as oms_name, link.name as link_name, on, loc
+        ORDER BY oms_name, link_name
+        WITH path, collect({node: on, site: loc, oms: oms_name, link: link_name}) as all_nodes
+        RETURN path, all_nodes
+        """
+    result = nc.query_to_list(nc.graphdb.manager, q, handle_id=int(node_handle_id))
+    
+    paths = []
+    for item in result:
+        # Build ordered path using graph traversal
+        all_nodes_data = item['all_nodes']
+        
+        if not all_nodes_data:
+            continue
+        
+        # Build adjacency graph from links
+        # Each link connects exactly 2 nodes
+        adjacency = {}  # node_id -> list of (neighbor_id, link_name)
+        node_lookup = {}  # node_id -> node_data
+        
+        # Group nodes by link
+        links_dict = {}
+        for node_data in all_nodes_data:
+            link_name = node_data['link']
+            node_id = node_data['node']['handle_id']
+            
+            if link_name not in links_dict:
+                links_dict[link_name] = []
+            links_dict[link_name].append(node_data)
+            node_lookup[node_id] = node_data
+        
+        # Build adjacency list
+        for link_name, link_nodes in links_dict.items():
+            if len(link_nodes) == 2:
+                node1_id = link_nodes[0]['node']['handle_id']
+                node2_id = link_nodes[1]['node']['handle_id']
+                
+                if node1_id not in adjacency:
+                    adjacency[node1_id] = []
+                if node2_id not in adjacency:
+                    adjacency[node2_id] = []
+                
+                adjacency[node1_id].append((node2_id, link_name))
+                adjacency[node2_id].append((node1_id, link_name))
+        
+        # Find path endpoints (nodes with only 1 connection) or start from any node
+        endpoints = [nid for nid, neighbors in adjacency.items() if len(neighbors) == 1]
+        
+        if not endpoints:
+            # No clear endpoints, start from first node
+            start_node = list(adjacency.keys())[0] if adjacency else None
+        else:
+            # Start from one endpoint
+            start_node = endpoints[0]
+        
+        if not start_node:
+            continue
+        
+        # Traverse the path using DFS
+        ordered_nodes = []
+        visited = set()
+        
+        def dfs(node_id):
+            if node_id in visited:
+                return
+            visited.add(node_id)
+            ordered_nodes.append(node_lookup[node_id])
+            
+            # Visit unvisited neighbors
+            if node_id in adjacency:
+                for neighbor_id, _ in adjacency[node_id]:
+                    if neighbor_id not in visited:
+                        dfs(neighbor_id)
+        
+        dfs(start_node)
+        
+        path_nodes = []
+        for node_data in ordered_nodes:
+            path_nodes.append({
+                'name': node_data['node']['name'],
+                'handle_id': node_data['node']['handle_id'],
+                'lng': float(str(node_data['site'].get('longitude', 0))),
+                'lat': float(str(node_data['site'].get('latitude', 0)))
+            })
+        
+        paths.append({
+            'id': item['path']['handle_id'],
+            'name': item['path']['name'],
+            'description': item['path'].get('description', ''),
+            'operational_state': item['path'].get('operational_state', ''),
+            'nodes': path_nodes
+        })
+    
+    response = HttpResponse(content_type='application/json')
+    json.dump({'paths': paths}, response)
+    return response
+
+
+@login_required
 def qr_lookup(request, name):
     hits = list(nc.get_nodes_by_name(nc.graphdb.manager, name))
     if len(hits) == 1:


### PR DESCRIPTION
## Optical Node Map Enhancements

This PR enhances the optical node map visualization with improved markers, interactive optical path selection, and direct navigation from optical path detail pages.

### Map Improvements
- **Smaller, cleaner markers**: Reduced marker size for better map visibility
- **Hover tooltips**: Node names appear on hover without requiring clicks
- **Double-click navigation**: Quick access to node detail pages
- **Optical Links instead of Cables**: Updated to show Optical_Link connections between optical nodes (removed TSS type filter to include all optical node types)

### Interactive Optical Path Visualization
- **Side panel with path selector**: Added 300px panel listing available optical paths when a node is selected
- **Visual path rendering**: Color-coded paths drawn on the map with zoom-aware offset calculations to prevent overlapping parallel paths
- **Path toggling**: Checkboxes to show/hide individual paths with automatic spacing adjustment
- **Smart path deduplication**: Prevents duplicate path entries when switching between nodes along the same path
- **Clickable path names**: Path names link directly to their detail pages

### Backend & API
- **New endpoint**: `/gmaps/optical-paths/<node_handle_id>.json` for fetching optical paths
- **Graph traversal**: DFS algorithm builds ordered node sequences from optical link relationships
- **Filtered results**: Returns only "In service" operational paths with proper geo-coordinates

### Direct Navigation
- **"Show in Optical Node Map" button**: Added to optical path detail pages
- **URL parameter support**: Map accepts `?path=<id>` for direct path linking
- **Auto-selection**: Map automatically finds, selects, displays, and centers on the specified path when navigating from detail pages

