### PR TITLE
Add new service report to find dependent svcs from a set of other services

### DIFF
--- a/src/niweb/apps/noclook/templates/noclook/reports/service_dependency_report.html
+++ b/src/niweb/apps/noclook/templates/noclook/reports/service_dependency_report.html
@@ -26,12 +26,8 @@
         <div class="well">
             <p>Found {{ dependent.services|length }} dependent service{{ dependent.services|length|pluralize }}.</p>
             <div>Services:
-                {% for row in services %}
-                    {% for dep in row.dependents %}
-                        <span> 
-                            {{ dep.name }},
-                        </span>
-                    {% endfor %}
+                {% for dep_svc in dependent.services %}
+                    <span>{{ dep_svc.name }}{% if not forloop.last %}, {% endif %}</span>
                 {% endfor %}
             </div>
         </div>

--- a/src/niweb/apps/noclook/templates/noclook/reports/service_dependency_report.html
+++ b/src/niweb/apps/noclook/templates/noclook/reports/service_dependency_report.html
@@ -1,0 +1,71 @@
+{% extends "base.html" %}
+{% load noclook_tags %}
+
+{% block title %}{{ block.super }} | Service dependencies{% endblock %}
+
+{% block content %}
+    {{ block.super }}
+    <h1>Dependent services</h1>
+    <h3>Get the services that depend on a set of services</h3>
+    <h6>Convert nordunet to sunet and vice versa</h6>
+    <div class="well">
+        <form action="" method="post">{% csrf_token %}
+            <div class="control-group">
+                <label for="id_services">Service IDs (comma, space or newline separated)</label>
+                <textarea id="id_services" name="services" rows="6" style="width:100%; box-sizing:border-box;"
+                          placeholder="SU-S003995, SU-S003982, SU-S003971, ...">{{ posted }}</textarea>
+            </div>
+            <div class="controls">
+                <input type="submit" class="btn btn-primary" value="Get dependent services" />
+                <a href="." class="btn">Reset</a>
+            </div>
+        </form>
+    </div>
+
+    {% if services %}
+        <div class="well">
+            <p>Found {{ services|length }} service{{ services|pluralize }}.</p>
+            <div>Services:
+                {% for row in services %}
+                    {% for dep in row.dependents %}
+                        <span> 
+                            {{ dep.name }},
+                        </span>
+                    {% endfor %}
+                {% endfor %}
+            </div>
+        </div>
+
+        <table class="table table-striped table-bordered table-condensed">
+            <thead>
+                <tr>
+                    <!-- <th>Service</th> -->
+                    <th>Dependent service</th>
+                    <th>Description</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for row in services %}
+                    {% if row.dependents %}
+                        {% for dep in row.dependents %}
+                            <tr>
+                                <!--<td>{{ row.service_name }}</td> -->
+                                <td><a href="{% noclook_node_to_url dep.handle_id %}">{{ dep.name }}</a></td>
+                                <td>{{ dep.description|default:"" }}</td>
+                            </tr>
+                        {% endfor %}
+                    {% else %}
+                        <tr class="muted">
+                            <!--<td>{{ row.service_name }}</td> -->
+                            <td colspan="3">
+                                {% if row.found %}No dependent services{% else %}Service not found{% endif %}
+                            </td>
+                        </tr>
+                    {% endif %}
+                {% endfor %}
+            </tbody>
+        </table>
+    {% elif posted %}
+        <p>No services found.</p>
+    {% endif %}
+{% endblock %}

--- a/src/niweb/apps/noclook/templates/noclook/reports/service_dependency_report.html
+++ b/src/niweb/apps/noclook/templates/noclook/reports/service_dependency_report.html
@@ -24,7 +24,7 @@
 
     {% if services %}
         <div class="well">
-            <p>Found {{ services|length }} service{{ services|pluralize }}.</p>
+            <p>Found {{ dependent.services|length }} dependent service{{ dependent.services|length|pluralize }}.</p>
             <div>Services:
                 {% for row in services %}
                     {% for dep in row.dependents %}

--- a/src/niweb/apps/noclook/templates/noclook/reports/service_dependency_report.html
+++ b/src/niweb/apps/noclook/templates/noclook/reports/service_dependency_report.html
@@ -42,6 +42,7 @@
                     <!-- <th>Service</th> -->
                     <th>Dependent service</th>
                     <th>Description</th>
+                    <th>Operational state</th>
                 </tr>
             </thead>
             <tbody>
@@ -52,13 +53,14 @@
                                 <!--<td>{{ row.service_name }}</td> -->
                                 <td><a href="{% noclook_node_to_url dep.handle_id %}">{{ dep.name }}</a></td>
                                 <td>{{ dep.description|default:"" }}</td>
+                                <td>{{ dep.operational_state|default:"" }}</td>
                             </tr>
                         {% endfor %}
                     {% else %}
                         <tr class="muted">
                             <!--<td>{{ row.service_name }}</td> -->
                             <td colspan="3">
-                                {% if row.found %}No dependent services{% else %}Service not found{% endif %}
+                                {% if row.found %}No dependent services{% else %}Service {{ row.service_name }} not found{% endif %}
                             </td>
                         </tr>
                     {% endif %}

--- a/src/niweb/apps/noclook/templates/noclook/reports/service_dependency_report.html
+++ b/src/niweb/apps/noclook/templates/noclook/reports/service_dependency_report.html
@@ -39,7 +39,7 @@
         <table class="table table-striped table-bordered table-condensed">
             <thead>
                 <tr>
-                    <!-- <th>Service</th> -->
+                    <th>Service</th>
                     <th>Dependent service</th>
                     <th>Description</th>
                     <th>Operational state</th>
@@ -50,7 +50,7 @@
                     {% if row.dependents %}
                         {% for dep in row.dependents %}
                             <tr>
-                                <!--<td>{{ row.service_name }}</td> -->
+                                <td>{{ row.service_name }}</td>
                                 <td><a href="{% noclook_node_to_url dep.handle_id %}">{{ dep.name }}</a></td>
                                 <td>{{ dep.description|default:"" }}</td>
                                 <td>{{ dep.operational_state|default:"" }}</td>
@@ -58,7 +58,7 @@
                         {% endfor %}
                     {% else %}
                         <tr class="muted">
-                            <!--<td>{{ row.service_name }}</td> -->
+                            <td>{{ row.service_name }}</td>
                             <td colspan="3">
                                 {% if row.found %}No dependent services{% else %}Service {{ row.service_name }} not found{% endif %}
                             </td>

--- a/src/niweb/apps/noclook/templates/noclook/reports/service_dependency_report.html
+++ b/src/niweb/apps/noclook/templates/noclook/reports/service_dependency_report.html
@@ -67,6 +67,13 @@
                 {% endfor %}
             </tbody>
         </table>
+
+        {% if dependent.services %}
+            <div class="clearfix" style="margin-bottom: 1em;">
+                {% ticket_info dependent.services %}
+            </div>
+        {% endif %}
+        
     {% elif posted %}
         <p>No services found.</p>
     {% endif %}

--- a/src/niweb/apps/noclook/urls.py
+++ b/src/niweb/apps/noclook/urls.py
@@ -81,6 +81,7 @@ urlpatterns = [
     path('reports/hosts/host-security-class/<status>/', report.host_security_class),
     re_path(r'^reports/unique-ids\.(?P<file_format>xls|csv)$', report.download_unique_ids),
     path('reports/unique-ids/', report.unique_ids),
+    path('reports/service-dependencies/', report.get_dependent_services, name='service_dependency_report'),
     re_path(r'^reports/rack-cables/(?P<handle_id>\d+)\.(?P<file_format>xls|csv)$', report.download_rack_cables),
 
     # -- list views

--- a/src/niweb/apps/noclook/views/report.py
+++ b/src/niweb/apps/noclook/views/report.py
@@ -22,6 +22,7 @@ import graphdb as nc
 def host_reports(request):
     return render(request, "noclook/reports/host_reports.html", {})
 
+
 @login_required
 def get_dependent_services(request):
     """
@@ -52,9 +53,7 @@ def get_dependent_services(request):
     # handle_id) so the ticket_info tag can summarise all dependent services.
     dependent_services = list(
         {
-            dep["handle_id"]: dep
-            for row in services
-            for dep in row["dependents"]
+            dep["handle_id"]: dep for row in services for dep in row["dependents"]
         }.values()
     )
     return render(
@@ -66,6 +65,7 @@ def get_dependent_services(request):
             "dependent": {"services": dependent_services},
         },
     )
+
 
 @login_required
 def host_users(request, host_user_name=None):

--- a/src/niweb/apps/noclook/views/report.py
+++ b/src/niweb/apps/noclook/views/report.py
@@ -48,10 +48,23 @@ def get_dependent_services(request):
             services = nc.query_to_list(
                 nc.graphdb.manager, q, service_names=service_names
             )
+    # Flatten every row's dependents into a single, de-duplicated list (keyed by
+    # handle_id) so the ticket_info tag can summarise all dependent services.
+    dependent_services = list(
+        {
+            dep["handle_id"]: dep
+            for row in services
+            for dep in row["dependents"]
+        }.values()
+    )
     return render(
         request,
         "noclook/reports/service_dependency_report.html",
-        {"services": services, "posted": posted},
+        {
+            "services": services,
+            "posted": posted,
+            "dependent": {"services": dependent_services},
+        },
     )
 
 @login_required

--- a/src/niweb/apps/noclook/views/report.py
+++ b/src/niweb/apps/noclook/views/report.py
@@ -42,7 +42,7 @@ def get_dependent_services(request):
                 ORDER BY dependent.name
                 RETURN service_name,
                        source IS NOT NULL AS found,
-                       collect(DISTINCT dependent { .name, .description, .handle_id }) AS dependents
+                       collect(DISTINCT dependent { .name, .description, .handle_id, .operational_state }) AS dependents
                 ORDER BY service_name
                 """
             services = nc.query_to_list(

--- a/src/niweb/apps/noclook/views/report.py
+++ b/src/niweb/apps/noclook/views/report.py
@@ -5,6 +5,8 @@ Created on 2012-06-11 5:48 PM
 @author: lundberg
 """
 
+import re
+
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render, get_object_or_404
 from django.http import Http404
@@ -18,72 +20,128 @@ import graphdb as nc
 
 @login_required
 def host_reports(request):
-    return render(request, 'noclook/reports/host_reports.html', {})
+    return render(request, "noclook/reports/host_reports.html", {})
 
+@login_required
+def get_dependent_services(request):
+    """
+    Take a list of service names (comma, whitespace or newline separated) and
+    return, for each one, the services that depend on it.
+    """
+    services = []
+    posted = ""
+    if request.method == "POST":
+        posted = request.POST.get("services", "")
+        service_names = [name for name in re.split(r"[\s,]+", posted) if name]
+        if service_names:
+            q = """
+                UNWIND $service_names AS service_name
+                OPTIONAL MATCH (source:Service {name: service_name})
+                OPTIONAL MATCH (source)<-[:Depends_on]-(dependent:Service)
+                WITH service_name, source, dependent
+                ORDER BY dependent.name
+                RETURN service_name,
+                       source IS NOT NULL AS found,
+                       collect(DISTINCT dependent { .name, .description, .handle_id }) AS dependents
+                ORDER BY service_name
+                """
+            services = nc.query_to_list(
+                nc.graphdb.manager, q, service_names=service_names
+            )
+    return render(
+        request,
+        "noclook/reports/service_dependency_report.html",
+        {"services": services, "posted": posted},
+    )
 
 @login_required
 def host_users(request, host_user_name=None):
     hosts = []
-    users = dict([(name, uid) for uid, name in get_node_type_tuples('Host User') if name])
+    users = dict(
+        [(name, uid) for uid, name in get_node_type_tuples("Host User") if name]
+    )
     host_user_id = users.get(host_user_name, None)
-    form = HostReportForm(request.GET or {'cut_off': '1'})
+    form = HostReportForm(request.GET or {"cut_off": "1"})
 
     if host_user_id:
-        q = '''
+        q = """
             MATCH (host_user:Host_User {handle_id: $handle_id})-[:Uses|Owns]->(host:Host)
             {where}
             RETURN host_user, collect(DISTINCT {data: host, type: [x in labels(host) where not x in ['Node', 'Host']]}) as hosts
-            '''.replace("{where}", form.to_where())
+            """.replace("{where}", form.to_where())
         hosts = nc.query_to_list(nc.graphdb.manager, q, handle_id=host_user_id)
-    elif host_user_name == 'Missing':
-        q = '''
+    elif host_user_name == "Missing":
+        q = """
             MATCH (host:Host)
             {where}
             RETURN collect(DISTINCT {data: host, type: [x in labels(host) where not x in ['Node', 'Host']]}) as hosts
-          '''.replace("{where}", form.to_where(additional="NOT (host)<-[:Uses|Owns]-()"))
+          """.replace(
+            "{where}", form.to_where(additional="NOT (host)<-[:Uses|Owns]-()")
+        )
         hosts = nc.query_to_list(nc.graphdb.manager, q)
-    elif host_user_name == 'All' or host_user_name is None:
-        q = '''
+    elif host_user_name == "All" or host_user_name is None:
+        q = """
             MATCH (host_user:Host_User)-[:Uses|Owns]->(host:Host) 
             {where}
             RETURN host_user, collect(DISTINCT {data: host, type: [x in labels(host) where not x in ['Node', 'Host']]}) as hosts
-            '''.replace("{where}", form.to_where())
+            """.replace("{where}", form.to_where())
         hosts = nc.query_to_list(nc.graphdb.manager, q)
     num_of_hosts = 0
     for item in hosts:
-        num_of_hosts += len(item['hosts'])
+        num_of_hosts += len(item["hosts"])
 
     urls = helpers.get_node_urls(hosts)
-    return render(request, 'noclook/reports/host_users.html',
-                              {'host_user_name': host_user_name, 'host_users': users, 'hosts': hosts,
-                               'num_of_hosts': num_of_hosts, 'urls': urls, 'form': form})
+    return render(
+        request,
+        "noclook/reports/host_users.html",
+        {
+            "host_user_name": host_user_name,
+            "host_users": users,
+            "hosts": hosts,
+            "num_of_hosts": num_of_hosts,
+            "urls": urls,
+            "form": form,
+        },
+    )
 
 
 @login_required
 def host_security_class(request, status=None, form=None):
-    where_statement = ''
-    if status == 'classified':
-        where_statement = 'and (exists(host.security_class) or exists(host.security_comment))'
-    elif status == 'not-classified':
-        where_statement = 'and (not(exists(host.security_class)) and not(exists(host.security_comment)))'
-    q = '''
+    where_statement = ""
+    if status == "classified":
+        where_statement = (
+            "and (exists(host.security_class) or exists(host.security_comment))"
+        )
+    elif status == "not-classified":
+        where_statement = "and (not(exists(host.security_class)) and not(exists(host.security_comment)))"
+    q = (
+        """
             MATCH (host:Host)
             WHERE not(host.operational_state = "Decommissioned") %s
             RETURN host
             ORDER BY host.noclook_last_seen DESC
-            ''' % where_statement
+            """
+        % where_statement
+    )
     hosts = nc.query_to_list(nc.graphdb.manager, q)
     urls = helpers.get_node_urls(hosts)
-    return render(request, 'noclook/reports/host_security_class.html',
-                              {'status': status, 'hosts': hosts, 'urls': urls})
+    return render(
+        request,
+        "noclook/reports/host_security_class.html",
+        {"status": status, "hosts": hosts, "urls": urls},
+    )
+
 
 @login_required
 def unique_ids(request):
     id_list = get_id_list(request.GET or None)
-    id_list = helpers.paginate(id_list, request.GET.get('page'))
+    id_list = helpers.paginate(id_list, request.GET.get("page"))
     search_form = SearchIdForm(request.GET or None)
-    return render(request, 'noclook/reports/unique_ids/list.html',
-        {'id_list': id_list, 'search_form': search_form})
+    return render(
+        request,
+        "noclook/reports/unique_ids/list.html",
+        {"id_list": id_list, "search_form": search_form},
+    )
 
 
 @login_required
@@ -97,53 +155,60 @@ def download_unique_ids(request, file_format=None):
 
     def create_dict(uid):
         return {
-            'ID': uid.unique_id,
-            'Reserve message': uid.reserve_message,
-            'Reserved': uid.reserved,
-            'Site': get_site(uid),
-            'Reserver': str(uid.reserver),
-            'Created': uid.created
+            "ID": uid.unique_id,
+            "Reserve message": uid.reserve_message,
+            "Reserved": uid.reserved,
+            "Site": get_site(uid),
+            "Reserver": str(uid.reserver),
+            "Created": uid.created,
         }
+
     table = [create_dict(uid) for uid in id_list]
     # using values is faster, a lot, but no nice header :( and no username
     # table = id_list.values()
-    if table and file_format == 'xls':
+    if table and file_format == "xls":
         return helpers.dicts_to_xls_response(table, header)
-    elif table and file_format == 'csv':
+    elif table and file_format == "csv":
         return helpers.dicts_to_csv_response(table, header)
     else:
         raise Http404
 
 
 def get_id_list(data=None):
-    id_list = NordunetUniqueId.objects.all().prefetch_related('reserver').prefetch_related('site')
+    id_list = (
+        NordunetUniqueId.objects.all()
+        .prefetch_related("reserver")
+        .prefetch_related("site")
+    )
     form = SearchIdForm(data)
     if form.is_valid():
         # do stuff
         data = form.cleaned_data
-        if data['reserved']:
-            id_list = id_list.filter(reserved=data['reserved'])
-        if data['reserve_message']:
-            id_list = id_list.filter(reserve_message__icontains=data['reserve_message'])
-        if data['site']:
-            id_list = id_list.filter(site=data['site'])
-        if data['id_type']:
-            id_list = id_list.filter(unique_id__startswith=data['id_type'])
-    return id_list.order_by('created').reverse()
+        if data["reserved"]:
+            id_list = id_list.filter(reserved=data["reserved"])
+        if data["reserve_message"]:
+            id_list = id_list.filter(reserve_message__icontains=data["reserve_message"])
+        if data["site"]:
+            id_list = id_list.filter(site=data["site"])
+        if data["id_type"]:
+            id_list = id_list.filter(unique_id__startswith=data["id_type"])
+    return id_list.order_by("created").reverse()
 
 
 @login_required
 def download_rack_cables(request, handle_id, file_format=None):
     nh = get_object_or_404(NodeHandle, pk=handle_id)
     node = nh.get_node()
-    location = '_'.join([loc['name'] for loc in node.get_location_path()['location_path']])
+    location = "_".join(
+        [loc["name"] for loc in node.get_location_path()["location_path"]]
+    )
     header = [
-        'EquipmentA',
-        'PortA',
-        'Cable',
-        'CableType',
-        'EquipmentB',
-        'PortB',
+        "EquipmentA",
+        "PortA",
+        "Cable",
+        "CableType",
+        "EquipmentB",
+        "PortB",
     ]
     q = """
     MATCH (r:Rack {handle_id: $handle_id})<-[:Located_in]-(n:Node)-[:Has]->(p:Port)<-[:Connected_to]-(c:Cable)-[:Connected_to]->(p2:Port)<-[:Has]-(n2:Node)
@@ -153,11 +218,15 @@ def download_rack_cables(request, handle_id, file_format=None):
 
     cables = nc.query_to_list(nc.graphdb.manager, q, handle_id=nh.handle_id)
 
-    file_name = 'rack-cables_{}_{}_{}.{}'.format(location, nh.node_name, nh.handle_id, file_format)
-    if cables and file_format == 'xls':
-        sheet_name = '{} - {}'.format(location, nh.node_name)
-        return helpers.dicts_to_xls_response(cables, header, file_name, sheet_name=sheet_name)
-    elif cables and file_format == 'csv':
+    file_name = "rack-cables_{}_{}_{}.{}".format(
+        location, nh.node_name, nh.handle_id, file_format
+    )
+    if cables and file_format == "xls":
+        sheet_name = "{} - {}".format(location, nh.node_name)
+        return helpers.dicts_to_xls_response(
+            cables, header, file_name, sheet_name=sheet_name
+        )
+    elif cables and file_format == "csv":
         return helpers.dicts_to_csv_response(cables, header, file_name)
     else:
         raise Http404

--- a/src/niweb/niweb/templates/base.html
+++ b/src/niweb/niweb/templates/base.html
@@ -107,6 +107,7 @@
                                 <ul class="dropdown-menu">
                                     <li><a href="/reports/hosts/">Host reports</a></li>
                                     <li><a href="/reports/unique-ids/">Unique IDs</a></li>
+                                    <li><a href="/reports/service-dependencies/">Service dependencies</a></li>
                                 </ul>
                             </li>
                             <li class="dropdown">
@@ -159,6 +160,7 @@
                         <li class="nav-header"><i class="icon-briefcase"></i> Reports</li>
                         <li><a href="/reports/hosts/">Host reports</a></li>
                         <li><a href="/reports/unique-ids/">Unique IDs</a></li>
+                        <li><a href="/reports/service-dependencies/">Service dependencies</a></li>
                         <li class="divider"></li>
                         <li class="nav-header"><i class="icon-map-marker"></i> Maps</li>
                         <li><a href="/gmaps/sites/">Site map</a></li>


### PR DESCRIPTION
Added a new Service Dependency Report page under reports that accepts a pasted list of service IDs and identifies all services that depend on them.
This provides a quick way to analyze downstream dependencies and identify affected services. It also simplifies the process of creating tickets for impacted services across both NORDUnet and SUNET. For example, the report can be used to determine which NORDUnet services depend on a given set of SUNET services and would therefore be affected by any changes to those services.
